### PR TITLE
Add missing backslash to makefile

### DIFF
--- a/src/python/espressomd/Makefile.am
+++ b/src/python/espressomd/Makefile.am
@@ -46,7 +46,7 @@ PYXFILES =  \
 	code_info.pyx \
 	cuda_init.pyx \
 	debye_hueckel.pyx \
-  electrostatics.pyx
+  electrostatics.pyx \
 	integrate.pyx \
 	interactions.pyx \
   lb.pyx \


### PR DESCRIPTION
Bug was introduced in 8902da9f79c218e543cdf2e39841d67801e95837